### PR TITLE
Use gh-db as primary PostgreSQL for app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- dlya prod-fastapi teper' ispol'zuetsya novyj PostgreSQL host gh-db i peremennaya DATABASE_URL prokladyvaetsya cherez ansible.
 - Dobavlena ansible-rol dlya nastrojki PostgreSQL na gh-db (db-admin, baza gh_db, pg_hba i UFW).
 
 feat(server): dobavil firmware_version v /api/devices (fw_ver ili "old")

--- a/ansible/host_vars/192.168.0.11.yml
+++ b/ansible/host_vars/192.168.0.11.yml
@@ -12,3 +12,5 @@ app_workers: 2
 app_env_file: /etc/growerhub.env
 python_cmd: /usr/bin/python3
 
+# TODO: perenesti parol' iz gh_db_url v zashchishchennoye mesto
+gh_db_url: "postgresql://db-admin:gh_db_admin_dev_1234@192.168.0.81:5432/gh_db"

--- a/ansible/roles/fastapi_app/defaults/main.yml
+++ b/ansible/roles/fastapi_app/defaults/main.yml
@@ -44,7 +44,7 @@ apt_packages:
 # отладочные флаги для FastAPI (читаются через config.py).
 # ----------------------------------------------------------
 
-app_env:
+app_env_base:
   # Настройки MQTT-клиента (используются и паблишером, и подписчиками)
   MQTT_HOST: "127.0.0.1"
   MQTT_PORT: "1883"
@@ -60,3 +60,7 @@ app_env:
 
   # Дополнительно можно прокидывать другие переменные,
   # если их читает config.py, например URL БД, токены и т.п.
+
+# DATABASE_URL dobavlyaetsya iz gh_db_url tol'ko pri nalichii hostovoy peremennoy
+app_env_database_overrides: "{{ {'DATABASE_URL': gh_db_url} if (gh_db_url is defined) else {} }}"
+app_env: "{{ app_env_base | combine(app_env_database_overrides) }}"


### PR DESCRIPTION
Perevesti prod-fastapi na novyj PostgreSQL gh-db cherez DATABASE_URL.

- V host_vars/192.168.0.11.yml dobavlen gh_db_url s vremennoj strokoj podklyucheniya i TODO na vyvod parolya v sekrety.
- Rol fastapi_app teper' formiruet app_env iz bazy i dobavlyaet DATABASE_URL pri nalichii gh_db_url, chtoby systemd peredal peremennuyu v FastAPI.
- CHANGELOG dopolnen opisaniem izmenenij.
