### PR TITLE
Add client-side login and token handling

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -165,7 +165,10 @@
 </head>
 <body>
     <div class="container">
-        <h1>🌱 Система умного полива</h1>
+        <div style="display: flex; justify-content: space-between; align-items: center; gap: 10px; flex-wrap: wrap;">
+            <h1 style="margin: 0;">🌱 Система умного полива</h1>
+            <button id="logoutBtn" style="background-color: #e74c3c;">Выйти</button>
+        </div>
         
         <div class="upload-section">
             <h3>📤 Загрузка прошивки OTA</h3>
@@ -180,6 +183,30 @@
     </div>
 
     <script>
+        const TOKEN_KEY = 'gh_access_token';
+        const accessToken = localStorage.getItem(TOKEN_KEY);
+
+        if (!accessToken) {
+            window.location.href = '/static/login.html';
+            throw new Error('no token');
+        }
+
+        const redirectToLogin = () => {
+            localStorage.removeItem(TOKEN_KEY);
+            window.location.href = '/static/login.html';
+        };
+
+        const authFetch = async (url, options = {}) => {
+            // Translitem: dobavlyaem Authorization ko vsem zaprosam i obrabatyvaem 401/403.
+            const opts = { ...options };
+            opts.headers = { ...(options.headers || {}), Authorization: `Bearer ${accessToken}` };
+            const response = await fetch(url, opts);
+            if (response.status === 401 || response.status === 403) {
+                redirectToLogin();
+            }
+            return response;
+        };
+
         let availableFirmware = [];
 
         const formatMoscowTime = (isoString) => {
@@ -220,7 +247,7 @@
 
         async function loadFirmwareVersions() {
             try {
-                const resp = await fetch('/api/firmware/versions', { cache: 'no-store' });
+                const resp = await authFetch('/api/firmware/versions', { cache: 'no-store' });
                 if (!resp.ok) throw new Error('bad status');
                 availableFirmware = await resp.json();
             } catch (error) {
@@ -241,7 +268,7 @@
 
         async function loadDevices() {
             try {
-                const response = await fetch('/api/devices');
+                const response = await authFetch('/api/devices');
                 const devices = await response.json();
                 const devicesDiv = document.getElementById('devices');
 
@@ -369,7 +396,7 @@
         async function deleteDevice(deviceId) {
             if (!confirm('Удалить устройство?')) return;
             try {
-                const response = await fetch(`/api/device/${deviceId}`, { method: 'DELETE' });
+                const response = await authFetch(`/api/device/${deviceId}`, { method: 'DELETE' });
                 if (response.ok) {
                     alert('Устройство удалено');
                     loadDevices();
@@ -393,7 +420,7 @@
                 light_duration: parseInt(document.getElementById(`light-duration-${deviceId}`).value)
             };
             try {
-                const response = await fetch(`/api/device/${deviceId}/settings`, {
+                const response = await authFetch(`/api/device/${deviceId}/settings`, {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(settings)
@@ -419,7 +446,7 @@
             formData.append('file', fileInput.files[0]);
             formData.append('version', versionInput.value);
             try {
-                const response = await fetch('/api/upload-firmware', { method: 'POST', body: formData });
+                const response = await authFetch('/api/upload-firmware', { method: 'POST', body: formData });
                 if (response.ok) {
                     alert('✅ Прошивка загружена!');
                     await loadFirmwareVersions();
@@ -439,7 +466,7 @@
                 return;
             }
             try {
-                const response = await fetch(`/api/device/${deviceId}/trigger-update`, {
+                const response = await authFetch(`/api/device/${deviceId}/trigger-update`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ device_id: deviceId, firmware_version: version })
@@ -459,6 +486,11 @@
             await loadDevices();
             setInterval(loadDevices, 10000);
         }
+
+        document.getElementById('logoutBtn').addEventListener('click', () => {
+            // Translitem: pri vyhode ochishchaem token i vedem na login.
+            redirectToLogin();
+        });
 
         initPage();
     </script>

--- a/static/login.html
+++ b/static/login.html
@@ -1,0 +1,159 @@
+﻿<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Вход в GrowerHub</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background: #f2f5f7;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .login-card {
+            background: #ffffff;
+            padding: 24px;
+            border-radius: 12px;
+            box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
+            width: 320px;
+        }
+        h1 {
+            margin: 0 0 16px;
+            text-align: center;
+            color: #2c3e50;
+        }
+        label {
+            display: block;
+            margin-bottom: 6px;
+            color: #34495e;
+            font-weight: bold;
+        }
+        input[type="email"],
+        input[type="password"] {
+            width: 100%;
+            padding: 10px;
+            margin-bottom: 12px;
+            border: 1px solid #dfe6e9;
+            border-radius: 6px;
+            box-sizing: border-box;
+        }
+        button {
+            width: 100%;
+            padding: 10px;
+            background: #27ae60;
+            color: #fff;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        button:hover {
+            background: #219150;
+        }
+        .error {
+            color: #c0392b;
+            margin-bottom: 10px;
+            min-height: 18px;
+            text-align: center;
+        }
+        .note {
+            font-size: 12px;
+            color: #7f8c8d;
+            text-align: center;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+    <div class="login-card">
+        <h1>GrowerHub</h1>
+        <div id="errorBox" class="error"></div>
+        <form id="loginForm">
+            <label for="email">Email</label>
+            <input type="email" id="email" name="email" required>
+
+            <label for="password">Пароль</label>
+            <input type="password" id="password" name="password" required>
+
+            <button type="submit">Войти</button>
+        </form>
+        <div class="note">Введите email и пароль для получения доступа</div>
+    </div>
+
+    <script>
+        const TOKEN_KEY = 'gh_access_token';
+
+        const redirectHome = () => {
+            window.location.href = '/';
+        };
+
+        const showError = (message) => {
+            document.getElementById('errorBox').textContent = message || '';
+        };
+
+        const clearToken = () => localStorage.removeItem(TOKEN_KEY);
+
+        const verifyToken = async (token) => {
+            // Translitem: probuem proverit' suschestvuyushchij token cherez /api/auth/me.
+            try {
+                const response = await fetch('/api/auth/me', {
+                    headers: { Authorization: `Bearer ${token}` }
+                });
+                return response.ok;
+            } catch (_error) {
+                return false;
+            }
+        };
+
+        const existingToken = localStorage.getItem(TOKEN_KEY);
+        if (existingToken) {
+            verifyToken(existingToken).then((valid) => {
+                if (valid) {
+                    redirectHome();
+                } else {
+                    clearToken();
+                }
+            });
+        }
+
+        document.getElementById('loginForm').addEventListener('submit', async (event) => {
+            event.preventDefault();
+            showError('');
+
+            const email = document.getElementById('email').value.trim();
+            const password = document.getElementById('password').value;
+
+            try {
+                const response = await fetch('/api/auth/login', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ email, password })
+                });
+
+                if (!response.ok) {
+                    throw new Error('login failed');
+                }
+
+                const payload = await response.json();
+                const token = payload && payload.access_token;
+                const type = payload && payload.token_type;
+                const isBearer = !type || String(type).toLowerCase() === 'bearer';
+
+                if (!token || !isBearer) {
+                    throw new Error('bad payload');
+                }
+
+                localStorage.setItem(TOKEN_KEY, token);
+                redirectHome();
+            } catch (_error) {
+                clearToken();
+                showError('Неверный email или пароль');
+            }
+        });
+    </script>
+</body>
+</html>

--- a/static/manual_watering.html
+++ b/static/manual_watering.html
@@ -129,6 +129,30 @@
     <div id="progressText">Нет активного полива</div>
 
     <script>
+        const TOKEN_KEY = 'gh_access_token';
+        const accessToken = localStorage.getItem(TOKEN_KEY);
+
+        if (!accessToken) {
+            window.location.href = '/static/login.html';
+            throw new Error('no token');
+        }
+
+        const redirectToLogin = () => {
+            localStorage.removeItem(TOKEN_KEY);
+            window.location.href = '/static/login.html';
+        };
+
+        const authFetch = async (url, options = {}) => {
+            // Translitem: universal'nyj fetch s dobavleniem Bearer i obrabotkoj 401/403.
+            const opts = { ...options };
+            opts.headers = { ...(options.headers || {}), Authorization: `Bearer ${accessToken}` };
+            const response = await fetch(url, opts);
+            if (response.status === 401 || response.status === 403) {
+                redirectToLogin();
+            }
+            return response;
+        };
+
         const deviceInput = document.getElementById("device_id");
         const durationSelect = document.getElementById("duration");
         const startBtn = document.getElementById("startBtn");
@@ -236,7 +260,7 @@
             }
 
             try {
-                const response = await fetch(`/api/manual-watering/status?device_id=${encodeURIComponent(deviceId)}`);
+                const response = await authFetch(`/api/manual-watering/status?device_id=${encodeURIComponent(deviceId)}`);
                 if (!response.ok) {
                     throw new Error(`HTTP ${response.status}`);
                 }
@@ -326,7 +350,7 @@
             showAck("Отправляем команду запуска...");
 
             try {
-                const response = await fetch("/api/manual-watering/start", {
+                const response = await authFetch("/api/manual-watering/start", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({ device_id: deviceId, duration_s: duration })
@@ -359,7 +383,7 @@
             showAck("Отправляем команду остановки...");
 
             try {
-                const response = await fetch("/api/manual-watering/stop", {
+                const response = await authFetch("/api/manual-watering/stop", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({ device_id: deviceId })
@@ -390,7 +414,7 @@
             showAck("Отправляем команду перезагрузки...");
 
             try {
-                const response = await fetch("/api/manual-watering/reboot", {
+                const response = await authFetch("/api/manual-watering/reboot", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({ device_id: deviceId })
@@ -434,7 +458,7 @@
         async function waitAckForReboot(correlationId, deviceId) {
             const url = `/api/manual-watering/wait-ack?correlation_id=${encodeURIComponent(correlationId)}&timeout_s=${WAIT_ACK_TIMEOUT_S}`;
             try {
-                const response = await fetch(url);
+                const response = await authFetch(url);
                 if (response.status === 408) {
                     return "Перезагрузка не подтверждена: превышено время ожидания ❌";
                 }
@@ -457,7 +481,7 @@
         async function waitAck(correlationId, deviceId) {
             const url = `/api/manual-watering/wait-ack?correlation_id=${encodeURIComponent(correlationId)}&timeout_s=${WAIT_ACK_TIMEOUT_S}`;
             try {
-                const response = await fetch(url);
+                const response = await authFetch(url);
                 if (response.status === 408) {
                     return "ACK не получен в заданное время ❌";
                 }


### PR DESCRIPTION
## Summary
- add a login page that authenticates via the API and stores the JWT token
- require a stored token on the main and manual watering pages with redirects on missing/invalid auth
- attach bearer tokens to frontend API calls and add logout support

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692341c39e248325add1cbeb5b65c5df)