### PR TITLE
Add plants and journal support

### DIFF
--- a/server/alembic/versions/d2e4a1c8c1f0_add_plants_and_journal.py
+++ b/server/alembic/versions/d2e4a1c8c1f0_add_plants_and_journal.py
@@ -1,0 +1,89 @@
+﻿"""add plants and journal tables
+
+Revision ID: d2e4a1c8c1f0
+Revises: a3e6b2e7d8f1
+Create Date: 2025-11-20 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "d2e4a1c8c1f0"
+down_revision = "a3e6b2e7d8f1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "plant_groups",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+    )
+
+    op.create_table(
+        "plants",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("planted_at", sa.DateTime(), nullable=False),
+        sa.Column("plant_group_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["plant_group_id"], ["plant_groups.id"], ondelete="SET NULL"),
+    )
+
+    op.create_table(
+        "plant_devices",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("plant_id", sa.Integer(), nullable=False),
+        sa.Column("device_id", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["plant_id"], ["plants.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["device_id"], ["devices.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("plant_id", "device_id", name="uq_plant_device_pair"),
+    )
+
+    op.create_table(
+        "plant_journal_entries",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("plant_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("type", sa.String(), nullable=False),
+        sa.Column("text", sa.Text(), nullable=True),
+        sa.Column("event_at", sa.DateTime(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["plant_id"], ["plants.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+    )
+
+    op.create_table(
+        "plant_journal_photos",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("journal_entry_id", sa.Integer(), nullable=False),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column("caption", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["journal_entry_id"], ["plant_journal_entries.id"], ondelete="CASCADE"
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("plant_journal_photos")
+    op.drop_table("plant_journal_entries")
+    op.drop_table("plant_devices")
+    op.drop_table("plants")
+    op.drop_table("plant_groups")

--- a/server/app/fastapi/routers/plants.py
+++ b/server/app/fastapi/routers/plants.py
@@ -1,0 +1,390 @@
+﻿from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import get_current_admin, get_current_user
+from app.fastapi.routers.devices import _device_to_out
+from app.models.database_models import (
+    DeviceDB,
+    PlantDB,
+    PlantDeviceDB,
+    PlantGroupDB,
+    PlantJournalEntryDB,
+    PlantJournalPhotoDB,
+    UserDB,
+)
+from app.models.device_schemas import AdminDeviceOut, DeviceOut
+from app.models.plant_schemas import (
+    AdminPlantOut,
+    PlantCreate,
+    PlantGroupCreate,
+    PlantGroupOut,
+    PlantJournalEntryCreate,
+    PlantJournalEntryOut,
+    PlantOut,
+    PlantUpdate,
+)
+from app.repositories.state_repo import DeviceStateLastRepository
+
+router = APIRouter()
+
+
+@router.get("/api/plant-groups", response_model=list[PlantGroupOut])
+async def list_plant_groups(
+    db: Session = Depends(get_db), current_user: UserDB = Depends(get_current_user)
+):
+    groups = db.query(PlantGroupDB).filter(PlantGroupDB.user_id == current_user.id).all()
+    return [
+        PlantGroupOut(id=group.id, name=group.name, user_id=group.user_id)
+        for group in groups
+    ]
+
+
+@router.post("/api/plant-groups", response_model=PlantGroupOut)
+async def create_plant_group(
+    payload: PlantGroupCreate,
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(get_current_user),
+):
+    group = PlantGroupDB(name=payload.name, user_id=current_user.id)
+    db.add(group)
+    db.commit()
+    db.refresh(group)
+    return PlantGroupOut(id=group.id, name=group.name, user_id=group.user_id)
+
+
+@router.delete("/api/plant-groups/{group_id}")
+async def delete_plant_group(
+    group_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(get_current_user),
+):
+    group = (
+        db.query(PlantGroupDB)
+        .filter(PlantGroupDB.id == group_id, PlantGroupDB.user_id == current_user.id)
+        .first()
+    )
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="gruppa ne najdena")
+
+    db.query(PlantDB).filter(
+        PlantDB.user_id == current_user.id, PlantDB.plant_group_id == group_id
+    ).update({PlantDB.plant_group_id: None})
+    db.delete(group)
+    db.commit()
+    return {"message": "group deleted"}
+
+
+@router.get("/api/plants", response_model=list[PlantOut])
+async def list_plants(
+    db: Session = Depends(get_db), current_user: UserDB = Depends(get_current_user)
+):
+    plants = db.query(PlantDB).filter(PlantDB.user_id == current_user.id).all()
+    state_repo = DeviceStateLastRepository()
+    current_time = datetime.utcnow()
+    online_window = timedelta(minutes=3)
+    return [
+        _build_plant_out(plant, db, state_repo, current_time, online_window, current_user)
+        for plant in plants
+    ]
+
+
+@router.post("/api/plants", response_model=PlantOut)
+async def create_plant(
+    payload: PlantCreate,
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(get_current_user),
+):
+    planted_at = payload.planted_at or datetime.utcnow()
+    plant = PlantDB(
+        name=payload.name,
+        planted_at=planted_at,
+        user_id=current_user.id,
+        plant_group_id=payload.plant_group_id,
+    )
+    db.add(plant)
+    db.commit()
+    db.refresh(plant)
+
+    state_repo = DeviceStateLastRepository()
+    current_time = datetime.utcnow()
+    online_window = timedelta(minutes=3)
+    return _build_plant_out(plant, db, state_repo, current_time, online_window, current_user)
+
+
+@router.get("/api/plants/{plant_id}", response_model=PlantOut)
+async def get_plant(
+    plant_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(get_current_user),
+):
+    plant = _get_user_plant(db, plant_id, current_user)
+    state_repo = DeviceStateLastRepository()
+    current_time = datetime.utcnow()
+    online_window = timedelta(minutes=3)
+    return _build_plant_out(plant, db, state_repo, current_time, online_window, current_user)
+
+
+@router.patch("/api/plants/{plant_id}", response_model=PlantOut)
+async def update_plant(
+    plant_id: int,
+    payload: PlantUpdate,
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(get_current_user),
+):
+    plant = _get_user_plant(db, plant_id, current_user)
+    update_data = payload.model_dump(exclude_unset=True)
+    if "name" in update_data:
+        plant.name = update_data["name"]
+    if "planted_at" in update_data:
+        plant.planted_at = update_data["planted_at"]
+    if "plant_group_id" in update_data:
+        plant.plant_group_id = update_data["plant_group_id"]
+
+    db.commit()
+    db.refresh(plant)
+
+    state_repo = DeviceStateLastRepository()
+    current_time = datetime.utcnow()
+    online_window = timedelta(minutes=3)
+    return _build_plant_out(plant, db, state_repo, current_time, online_window, current_user)
+
+
+@router.delete("/api/plants/{plant_id}")
+async def delete_plant(
+    plant_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(get_current_user),
+):
+    plant = _get_user_plant(db, plant_id, current_user)
+
+    db.query(PlantDeviceDB).filter(PlantDeviceDB.plant_id == plant.id).delete()
+    db.query(PlantJournalEntryDB).filter(PlantJournalEntryDB.plant_id == plant.id).delete()
+    db.delete(plant)
+    db.commit()
+    return {"message": "plant deleted"}
+
+
+@router.post("/api/plants/{plant_id}/devices/{device_id}", response_model=PlantOut)
+async def attach_device_to_plant(
+    plant_id: int,
+    device_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(get_current_user),
+):
+    plant = _get_user_plant(db, plant_id, current_user)
+    device = (
+        db.query(DeviceDB)
+        .filter(DeviceDB.id == device_id, DeviceDB.user_id == current_user.id)
+        .first()
+    )
+    if not device:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="ustrojstvo ne najdeno")
+
+    existing = (
+        db.query(PlantDeviceDB)
+        .filter(PlantDeviceDB.plant_id == plant.id, PlantDeviceDB.device_id == device.id)
+        .first()
+    )
+    if not existing:
+        link = PlantDeviceDB(plant_id=plant.id, device_id=device.id)
+        db.add(link)
+        db.commit()
+
+    state_repo = DeviceStateLastRepository()
+    current_time = datetime.utcnow()
+    online_window = timedelta(minutes=3)
+    return _build_plant_out(plant, db, state_repo, current_time, online_window, current_user)
+
+
+@router.delete("/api/plants/{plant_id}/devices/{device_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def detach_device_from_plant(
+    plant_id: int,
+    device_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(get_current_user),
+):
+    _get_user_plant(db, plant_id, current_user)
+    device = (
+        db.query(DeviceDB)
+        .filter(DeviceDB.id == device_id, DeviceDB.user_id == current_user.id)
+        .first()
+    )
+    if not device:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="ustrojstvo ne najdeno")
+
+    db.query(PlantDeviceDB).filter(
+        PlantDeviceDB.plant_id == plant_id, PlantDeviceDB.device_id == device_id
+    ).delete()
+    db.commit()
+    return None
+
+
+@router.get("/api/plants/{plant_id}/journal", response_model=list[PlantJournalEntryOut])
+async def list_plant_journal(
+    plant_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(get_current_user),
+):
+    _get_user_plant(db, plant_id, current_user)
+    entries = (
+        db.query(PlantJournalEntryDB)
+        .filter(PlantJournalEntryDB.plant_id == plant_id)
+        .order_by(PlantJournalEntryDB.event_at.desc())
+        .all()
+    )
+    return [_build_journal_out(entry, db) for entry in entries]
+
+
+@router.post("/api/plants/{plant_id}/journal", response_model=PlantJournalEntryOut)
+async def create_journal_entry(
+    plant_id: int,
+    payload: PlantJournalEntryCreate,
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(get_current_user),
+):
+    _get_user_plant(db, plant_id, current_user)
+    event_at = payload.event_at or datetime.utcnow()
+    entry = PlantJournalEntryDB(
+        plant_id=plant_id,
+        user_id=current_user.id,
+        type=payload.type,
+        text=payload.text,
+        event_at=event_at,
+    )
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+
+    photo_urls = payload.photo_urls or []
+    for url in photo_urls:
+        photo = PlantJournalPhotoDB(journal_entry_id=entry.id, url=url)
+        db.add(photo)
+    if photo_urls:
+        db.commit()
+
+    return _build_journal_out(entry, db)
+
+
+@router.delete("/api/plants/{plant_id}/journal/{entry_id}")
+async def delete_journal_entry(
+    plant_id: int,
+    entry_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserDB = Depends(get_current_user),
+):
+    _get_user_plant(db, plant_id, current_user)
+    entry = (
+        db.query(PlantJournalEntryDB)
+        .filter(
+            PlantJournalEntryDB.id == entry_id,
+            PlantJournalEntryDB.plant_id == plant_id,
+            PlantJournalEntryDB.user_id == current_user.id,
+        )
+        .first()
+    )
+    if not entry:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="zapis' ne najdena")
+
+    db.delete(entry)
+    db.commit()
+    return {"message": "entry deleted"}
+
+
+@router.get("/api/admin/plants", response_model=list[AdminPlantOut])
+async def admin_list_plants(
+    db: Session = Depends(get_db), admin: UserDB = Depends(get_current_admin)
+):
+    rows = (
+        db.query(PlantDB, UserDB, PlantGroupDB)
+        .outerjoin(UserDB, PlantDB.user_id == UserDB.id)
+        .outerjoin(PlantGroupDB, PlantDB.plant_group_id == PlantGroupDB.id)
+        .all()
+    )
+    result: list[AdminPlantOut] = []
+    for plant, owner, group in rows:
+        result.append(
+            AdminPlantOut(
+                id=plant.id,
+                name=plant.name,
+                owner_email=owner.email if owner else None,
+                owner_username=owner.username if owner else None,
+                owner_id=owner.id if owner else None,
+                group_name=group.name if group else None,
+            )
+        )
+    return result
+
+
+def _get_user_plant(db: Session, plant_id: int, current_user: UserDB) -> PlantDB:
+    plant = (
+        db.query(PlantDB)
+        .filter(PlantDB.id == plant_id, PlantDB.user_id == current_user.id)
+        .first()
+    )
+    if not plant:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="rastenie ne najdeno")
+    return plant
+
+
+def _build_journal_out(entry: PlantJournalEntryDB, db: Session) -> PlantJournalEntryOut:
+    photos = (
+        db.query(PlantJournalPhotoDB)
+        .filter(PlantJournalPhotoDB.journal_entry_id == entry.id)
+        .all()
+    )
+    return PlantJournalEntryOut(
+        id=entry.id,
+        plant_id=entry.plant_id,
+        user_id=entry.user_id,
+        type=entry.type,
+        text=entry.text,
+        event_at=entry.event_at,
+        created_at=entry.created_at,
+        photos=[
+            {
+                "id": photo.id,
+                "url": photo.url,
+                "caption": photo.caption,
+            }
+            for photo in photos
+        ],
+    )
+
+
+def _build_plant_out(
+    plant: PlantDB,
+    db: Session,
+    state_repo: DeviceStateLastRepository,
+    current_time: datetime,
+    online_window: timedelta,
+    current_user: UserDB,
+) -> PlantOut:
+    group = None
+    if plant.plant_group_id:
+        group = db.query(PlantGroupDB).filter(PlantGroupDB.id == plant.plant_group_id).first()
+
+    device_links = (
+        db.query(DeviceDB)
+        .join(PlantDeviceDB, PlantDeviceDB.device_id == DeviceDB.id)
+        .filter(PlantDeviceDB.plant_id == plant.id, DeviceDB.user_id == current_user.id)
+        .all()
+    )
+    devices_out: list[DeviceOut] = [
+        _device_to_out(device, state_repo, current_time, online_window) for device in device_links
+    ]
+
+    return PlantOut(
+        id=plant.id,
+        name=plant.name,
+        planted_at=plant.planted_at,
+        user_id=plant.user_id,
+        plant_group=PlantGroupOut(id=group.id, name=group.name, user_id=group.user_id)
+        if group
+        else None,
+        devices=devices_out,
+    )

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -12,6 +12,7 @@ from app.fastapi.routers import devices as devices_router
 from app.fastapi.routers import firmware as firmware_router
 from app.fastapi.routers import history as history_router
 from app.fastapi.routers import manual_watering as manual_watering_router
+from app.fastapi.routers import plants as plants_router
 from app.fastapi.routers import users as users_router
 from app.mqtt.lifecycle import (
     init_ack_subscriber,
@@ -83,6 +84,7 @@ app.include_router(manual_watering_router.router, tags=["Manual watering"])
 app.include_router(devices_router.router, tags=["Devices"])
 app.include_router(history_router.router, tags=["History"])
 app.include_router(firmware_router.router, tags=["Firmware"])
+app.include_router(plants_router.router, tags=["Plants"])
 
 
 def remount_firmware_static(settings: Settings | None = None) -> None:

--- a/server/app/models/database_models.py
+++ b/server/app/models/database_models.py
@@ -130,6 +130,87 @@ class UserAuthIdentityDB(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
+
+class PlantGroupDB(Base):
+    """Translitem: gruppa rastenij dlja organizacii po polkam/boksam."""
+
+    __tablename__ = "plant_groups"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    name = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class PlantDB(Base):
+    """Translitem: model' rastenija s privyazkoj k polzovatelyu i gruppe."""
+
+    __tablename__ = "plants"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    name = Column(String, nullable=False)
+    planted_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    plant_group_id = Column(
+        Integer,
+        ForeignKey("plant_groups.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class PlantDeviceDB(Base):
+    """Translitem: svyaz rastenija s ustrojstvami."""
+
+    __tablename__ = "plant_devices"
+    __table_args__ = (
+        UniqueConstraint("plant_id", "device_id", name="uq_plant_device_pair"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    plant_id = Column(Integer, ForeignKey("plants.id", ondelete="CASCADE"), nullable=False)
+    device_id = Column(Integer, ForeignKey("devices.id", ondelete="CASCADE"), nullable=False)
+
+
+class PlantJournalEntryDB(Base):
+    """Translitem: zapis' zhurnala aktivnosti rastenija."""
+
+    __tablename__ = "plant_journal_entries"
+
+    id = Column(Integer, primary_key=True)
+    plant_id = Column(Integer, ForeignKey("plants.id", ondelete="CASCADE"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    type = Column(String, nullable=False)
+    text = Column(Text, nullable=True)
+    event_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class PlantJournalPhotoDB(Base):
+    """Translitem: foto-prilozhenie k zapisjam zhurnala."""
+
+    __tablename__ = "plant_journal_photos"
+
+    id = Column(Integer, primary_key=True)
+    journal_entry_id = Column(
+        Integer,
+        ForeignKey("plant_journal_entries.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    url = Column(String, nullable=False)
+    caption = Column(String, nullable=True)
+
 # Pydantic РјРѕРґРµР»Рё
 class DeviceSettings(BaseModel):
     target_moisture: float

--- a/server/app/models/plant_schemas.py
+++ b/server/app/models/plant_schemas.py
@@ -1,0 +1,88 @@
+﻿from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+from app.models.device_schemas import DeviceOut
+
+
+class PlantGroupCreate(BaseModel):
+    """Translitem: sozdat' gruppu rastenij."""
+
+    name: str
+
+
+class PlantGroupOut(BaseModel):
+    """Translitem: gruppa rastenij v otvetah API."""
+
+    id: int
+    name: str
+    user_id: Optional[int] = None
+
+
+class PlantCreate(BaseModel):
+    """Translitem: sozdanie rastenija."""
+
+    name: str
+    planted_at: Optional[datetime] = None
+    plant_group_id: Optional[int] = None
+
+
+class PlantUpdate(BaseModel):
+    """Translitem: obnovlenie rastenija."""
+
+    name: Optional[str] = None
+    planted_at: Optional[datetime] = None
+    plant_group_id: Optional[int] = None
+
+
+class PlantOut(BaseModel):
+    """Translitem: rasshirennoe opisanie rastenija."""
+
+    id: int
+    name: str
+    planted_at: datetime
+    user_id: Optional[int] = None
+    plant_group: Optional[PlantGroupOut] = None
+    devices: list[DeviceOut] = []
+
+
+class PlantJournalPhotoOut(BaseModel):
+    """Translitem: opisanie foto v zhurnale."""
+
+    id: int
+    url: str
+    caption: Optional[str] = None
+
+
+class PlantJournalEntryCreate(BaseModel):
+    """Translitem: sozdanie zapisi zhurnala rastenija."""
+
+    type: Literal["watering", "feeding", "note", "photo", "other"]
+    text: Optional[str] = None
+    event_at: Optional[datetime] = None
+    photo_urls: Optional[list[str]] = None
+
+
+class PlantJournalEntryOut(BaseModel):
+    """Translitem: zapis' zhurnala v otvete."""
+
+    id: int
+    plant_id: int
+    user_id: Optional[int] = None
+    type: str
+    text: Optional[str] = None
+    event_at: datetime
+    created_at: datetime
+    photos: list[PlantJournalPhotoOut] = []
+
+
+class AdminPlantOut(BaseModel):
+    """Translitem: zapis' rastenija dlya admina."""
+
+    id: int
+    name: str
+    owner_email: Optional[str] = None
+    owner_username: Optional[str] = None
+    owner_id: Optional[int] = None
+    group_name: Optional[str] = None

--- a/server/tests/test_plants_api.py
+++ b/server/tests/test_plants_api.py
@@ -1,0 +1,120 @@
+﻿import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+import app.main
+from app.core.database import get_db
+from app.models.database_models import Base, DeviceDB, PlantDeviceDB, PlantJournalEntryDB
+from tests.test_auth_users import (
+    TestingSessionLocal,
+    _create_user,
+    _login_and_get_token,
+    _override_get_db,
+    _patched_client,
+    _test_db_create_schema,
+    _test_db_drop_schema,
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    _test_db_drop_schema()
+    _test_db_create_schema()
+    import app.core.security as security_module  # noqa: WPS433
+
+    app.main.app.dependency_overrides[get_db] = _override_get_db
+    app.main.app.dependency_overrides[security_module.get_db] = _override_get_db
+    state_patcher = patch(
+        "app.repositories.state_repo.DeviceStateLastRepository.get_state",
+        return_value=None,
+    )
+    state_patcher.start()
+    try:
+        with _patched_client() as patched:
+            yield patched
+    finally:
+        app.main.app.dependency_overrides.pop(get_db, None)
+        app.main.app.dependency_overrides.pop(security_module.get_db, None)
+        _test_db_drop_schema()
+        state_patcher.stop()
+
+
+def test_create_plant_sets_owner(client: TestClient):
+    user = _create_user("plant-owner@example.com", "secret")
+    token = _login_and_get_token(client, user.email, "secret")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    response = client.post("/api/plants", json={"name": "Basil"}, headers=headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["user_id"] == user.id
+
+
+def test_attach_device_to_plant(client: TestClient):
+    user = _create_user("plant-device@example.com", "secret")
+    session = TestingSessionLocal()
+    try:
+        device = DeviceDB(device_id="dev-plant", name="Device Plant", user_id=user.id)
+        session.add(device)
+        session.commit()
+        session.refresh(device)
+    finally:
+        session.close()
+
+    token = _login_and_get_token(client, user.email, "secret")
+    headers = {"Authorization": f"Bearer {token}"}
+    plant_resp = client.post("/api/plants", json={"name": "Rose"}, headers=headers)
+    plant_id = plant_resp.json()["id"]
+
+    link_resp = client.post(
+        f"/api/plants/{plant_id}/devices/{device.id}",
+        headers=headers,
+    )
+    assert link_resp.status_code == 200
+
+    list_resp = client.get("/api/plants", headers=headers)
+    assert list_resp.status_code == 200
+    plants = list_resp.json()
+    assert any(
+        any(dev["id"] == device.id for dev in plant.get("devices", []))
+        for plant in plants
+    )
+
+    session = TestingSessionLocal()
+    try:
+        link = session.query(PlantDeviceDB).filter(PlantDeviceDB.plant_id == plant_id).first()
+        assert link is not None
+    finally:
+        session.close()
+
+
+def test_create_journal_entry(client: TestClient):
+    user = _create_user("plant-journal@example.com", "secret")
+    token = _login_and_get_token(client, user.email, "secret")
+    headers = {"Authorization": f"Bearer {token}"}
+    plant_id = client.post("/api/plants", json={"name": "Mint"}, headers=headers).json()["id"]
+
+    entry_resp = client.post(
+        f"/api/plants/{plant_id}/journal",
+        json={"type": "note", "text": "poliv 1l"},
+        headers=headers,
+    )
+    assert entry_resp.status_code == 200
+
+    list_resp = client.get(f"/api/plants/{plant_id}/journal", headers=headers)
+    assert list_resp.status_code == 200
+    entries = list_resp.json()
+    assert any(entry.get("text") == "poliv 1l" for entry in entries)
+
+    session = TestingSessionLocal()
+    try:
+        db_entry = (
+            session.query(PlantJournalEntryDB)
+            .filter(PlantJournalEntryDB.plant_id == plant_id)
+            .order_by(PlantJournalEntryDB.id.desc())
+            .first()
+        )
+        assert db_entry is not None
+    finally:
+        session.close()

--- a/static/admin_plants.html
+++ b/static/admin_plants.html
@@ -1,0 +1,55 @@
+﻿<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Админ: растения</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; background: #f5f5f5; }
+        table { width: 100%; border-collapse: collapse; background: #fff; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background: #f0f0f0; }
+    </style>
+</head>
+<body>
+    <h1>Админ: растения</h1>
+    <p><a href="admin_devices.html">К устройствам</a></p>
+    <table>
+        <thead>
+            <tr><th>ID</th><th>Имя</th><th>Владелец</th><th>Группа</th></tr>
+        </thead>
+        <tbody id="plants-body"></tbody>
+    </table>
+
+    <script>
+        const TOKEN_KEY = 'gh_access_token';
+        const token = localStorage.getItem(TOKEN_KEY);
+        if (!token) { window.location.href = '/login.html'; }
+
+        const authFetch = async (url, options = {}) => {
+            const opts = { ...options };
+            opts.headers = { ...(options.headers || {}), Authorization: `Bearer ${token}` };
+            const resp = await fetch(url, opts);
+            if (resp.status === 401 || resp.status === 403) {
+                localStorage.removeItem(TOKEN_KEY);
+                window.location.href = '/login.html';
+            }
+            return resp;
+        };
+
+        async function loadPlants() {
+            const resp = await authFetch('/api/admin/plants');
+            const plants = await resp.json();
+            const tbody = document.getElementById('plants-body');
+            tbody.innerHTML = '';
+            plants.forEach(p => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${p.id}</td><td>${p.name}</td><td>${p.owner_email || ''} (${p.owner_username || ''})</td><td>${p.group_name || ''}</td>`;
+                tbody.appendChild(tr);
+            });
+        }
+
+        loadPlants();
+    </script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -155,6 +155,71 @@
             color: #888;
             text-align: right;
         }
+        .plant-card {
+            border: 1px solid #ddd;
+            padding: 15px;
+            border-radius: 8px;
+            margin: 10px 0;
+            background: #fdfdfd;
+        }
+        .plant-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+        .group-badge {
+            background: #e0f7fa;
+            color: #006064;
+            padding: 4px 8px;
+            border-radius: 12px;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .group-badge button {
+            background: transparent;
+            color: #006064;
+            border: none;
+            padding: 0 4px;
+            cursor: pointer;
+        }
+        .plant-actions {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin-top: 8px;
+        }
+        .plant-devices {
+            margin-top: 10px;
+            font-size: 14px;
+        }
+        .group-list {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+            margin: 8px 0;
+        }
+        .group-pill {
+            background: #eef2f7;
+            padding: 6px 10px;
+            border-radius: 12px;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .group-pill button {
+            background: transparent;
+            border: none;
+            cursor: pointer;
+            color: #c0392b;
+        }
+        .journal-link {
+            background: #1976D2;
+            color: #fff;
+        }
     </style>
 </head>
 <body>
@@ -173,7 +238,23 @@
             <input type="text" id="firmwareVersion" placeholder="Версия (например: 1.1.0)">
             <button onclick="uploadFirmware()">Загрузить прошивку</button>
         </div>
-        
+
+        <div id="plants-section">
+            <h2>Мои растения</h2>
+            <div class="plant-actions">
+                <input type="text" id="new-plant-name" placeholder="Название растения">
+                <input type="datetime-local" id="new-plant-date">
+                <button onclick="createPlant()">Добавить растение</button>
+            </div>
+            <div class="plant-actions">
+                <input type="text" id="new-group-name" placeholder="Название группы">
+                <button onclick="createGroupFromInput()">Создать группу</button>
+            </div>
+            <div id="group-list" class="group-list"></div>
+            <div id="plants"></div>
+        </div>
+
+        <h2>Свободные устройства</h2>
         <div id="devices">
             <p>Загрузка устройств...</p>
         </div>
@@ -242,6 +323,162 @@
             return String(value).replace(/[&<>"']/g, ch => map[ch]);
         };
 
+        let plants = [];
+        let plantGroups = [];
+        let assignedDeviceIds = new Set();
+
+        async function loadPlantGroups() {
+            try {
+                const resp = await authFetch('/api/plant-groups');
+                plantGroups = await resp.json();
+                renderGroupList();
+            } catch (error) {
+                console.error('gruppy: oshibka zagruzki', error);
+            }
+        }
+
+        async function loadPlants() {
+            try {
+                const resp = await authFetch('/api/plants');
+                plants = await resp.json();
+                assignedDeviceIds = new Set();
+                plants.forEach(p => {
+                    (p.devices || []).forEach(d => assignedDeviceIds.add(d.id));
+                });
+                renderPlants();
+            } catch (error) {
+                console.error('rasteniya: oshibka zagruzki', error);
+            }
+        }
+
+        function renderGroupList() {
+            const list = document.getElementById('group-list');
+            if (!list) return;
+            if (!plantGroups.length) {
+                list.innerHTML = '<span>Группы не созданы</span>';
+                return;
+            }
+            list.innerHTML = '';
+            plantGroups.forEach(group => {
+                const pill = document.createElement('div');
+                pill.className = 'group-pill';
+                pill.innerHTML = `${escapeHtml(group.name)} <button title="Удалить группу" onclick="deleteGroup(${group.id})">✖</button>`;
+                list.appendChild(pill);
+            });
+        }
+
+        async function createGroupFromInput() {
+            const nameInput = document.getElementById('new-group-name');
+            if (!nameInput.value.trim()) return alert('Введите имя группы');
+            await createGroup(nameInput.value.trim());
+            nameInput.value = '';
+        }
+
+        async function createGroup(name) {
+            try {
+                const resp = await authFetch('/api/plant-groups', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name })
+                });
+                if (resp.ok) {
+                    await loadPlantGroups();
+                }
+            } catch (error) {
+                console.error('sozdanie gruppy: oshibka', error);
+            }
+        }
+
+        async function deleteGroup(groupId) {
+            if (!confirm('Удалить группу и отвязать растения?')) return;
+            try {
+                const resp = await authFetch(`/api/plant-groups/${groupId}`, { method: 'DELETE' });
+                if (resp.ok) {
+                    await refreshData();
+                }
+            } catch (error) {
+                console.error('udalit gruppu: oshibka', error);
+            }
+        }
+
+        async function createPlant() {
+            const nameInput = document.getElementById('new-plant-name');
+            const dateInput = document.getElementById('new-plant-date');
+            if (!nameInput.value.trim()) return alert('Введите название растения');
+            const payload = { name: nameInput.value.trim() };
+            if (dateInput.value) {
+                payload.planted_at = new Date(dateInput.value).toISOString();
+            }
+            try {
+                const resp = await authFetch('/api/plants', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                if (resp.ok) {
+                    nameInput.value = '';
+                    dateInput.value = '';
+                    await refreshData();
+                }
+            } catch (error) {
+                console.error('sozdanie rastenija: oshibka', error);
+            }
+        }
+
+        function renderPlants() {
+            const container = document.getElementById('plants');
+            if (!container) return;
+            if (!plants.length) {
+                container.innerHTML = '<p>Растения не найдены. Добавьте первое растение.</p>';
+                return;
+            }
+            container.innerHTML = '';
+            plants.forEach(plant => {
+                const card = document.createElement('div');
+                card.className = 'plant-card';
+                const groupLabel = plant.plant_group ? `<span class="group-badge">${escapeHtml(plant.plant_group.name)} <button title="Убрать из группы" onclick="setPlantGroup(${plant.id}, null)">✖</button></span>` : '<span style="color:#888;">Без группы</span>';
+                const devices = (plant.devices || []).map(d => `<li>${escapeHtml(d.name || d.device_id)} — ${d.is_online ? 'онлайн' : 'офлайн'}</li>`).join('') || '<li>Нет привязанных устройств</li>';
+                const selectOptions = ['<option value="">Без группы</option>', ...plantGroups.map(g => `<option value="${g.id}" ${plant.plant_group && g.id === plant.plant_group.id ? 'selected' : ''}>${escapeHtml(g.name)}</option>`)].join('');
+                card.innerHTML = `
+                    <div class="plant-header">
+                        <h3>${escapeHtml(plant.name)}</h3>
+                        <div>${groupLabel}</div>
+                    </div>
+                    <div class="plant-actions">
+                        <label>Группа:
+                            <select onchange="setPlantGroup(${plant.id}, this.value || null)">${selectOptions}</select>
+                        </label>
+                        <button class="journal-link" onclick="goToJournal(${plant.id})">Журнал</button>
+                    </div>
+                    <div class="plant-devices">
+                        <strong>Устройства:</strong>
+                        <ul>${devices}</ul>
+                    </div>
+                `;
+                container.appendChild(card);
+            });
+        }
+
+        async function setPlantGroup(plantId, groupId) {
+            const payload = { plant_group_id: groupId === null || groupId === '' ? null : Number(groupId) };
+            try {
+                const resp = await authFetch(`/api/plants/${plantId}`, {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                if (resp.ok) {
+                    await refreshData();
+                }
+            } catch (error) {
+                console.error('ustanovka gruppy: oshibka', error);
+            }
+        }
+
+        function goToJournal(plantId) {
+            window.location.href = `plant_journal.html?plant_id=${encodeURIComponent(plantId)}`;
+        }
+
         async function loadFirmwareVersions() {
             try {
                 const resp = await authFetch('/api/firmware/versions', { cache: 'no-store' });
@@ -267,16 +504,17 @@
             try {
                 const response = await authFetch('/api/devices/my');
                 const devices = await response.json();
+                const freeDevices = devices.filter(d => !assignedDeviceIds.has(d.id));
                 const devicesDiv = document.getElementById('devices');
 
-                if (!Array.isArray(devices) || devices.length === 0) {
-                    devicesDiv.innerHTML = '<p>Устройства не найдены. Подключите устройство Grovika к системе.</p>';
+                if (!Array.isArray(freeDevices) || freeDevices.length === 0) {
+                    devicesDiv.innerHTML = '<p>Свободных устройств нет. Освободите или добавьте устройство.</p>';
                     return;
                 }
 
                 devicesDiv.innerHTML = '';
 
-                devices.forEach(device => {
+                freeDevices.forEach(device => {
                     const deviceClass = device.is_watering ? 'watering' : (device.is_light_on ? 'light-on' : '');
                     const deviceDiv = document.createElement('div');
                     deviceDiv.className = `device ${deviceClass}`;
@@ -467,8 +705,14 @@
 
         async function initPage() {
             await loadFirmwareVersions();
+            await refreshData();
+            setInterval(refreshData, 10000);
+        }
+
+        async function refreshData() {
+            await loadPlantGroups();
+            await loadPlants();
             await loadDevices();
-            setInterval(loadDevices, 10000);
         }
 
         document.getElementById('logoutBtn').addEventListener('click', () => {

--- a/static/plant_journal.html
+++ b/static/plant_journal.html
@@ -1,0 +1,149 @@
+﻿<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Журнал растения</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; background: #f7f9fb; }
+        .container { max-width: 900px; margin: 0 auto; background: #fff; padding: 20px; border-radius: 10px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+        .entry { border-bottom: 1px solid #eee; padding: 10px 0; }
+        .entry:last-child { border-bottom: none; }
+        .photos img { max-width: 120px; margin-right: 10px; border-radius: 6px; }
+        .form-row { margin: 10px 0; display: flex; gap: 10px; flex-wrap: wrap; }
+        label { display: flex; flex-direction: column; gap: 4px; }
+        input, textarea, select, button { padding: 8px; border: 1px solid #ddd; border-radius: 6px; }
+        button { background: #4CAF50; color: #fff; cursor: pointer; }
+        button:hover { background: #43a047; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div style="display:flex; justify-content: space-between; align-items: center; gap: 10px; flex-wrap: wrap;">
+            <h1 id="plant-title">Журнал растения</h1>
+            <button onclick="window.location.href='index.html'">На главную</button>
+        </div>
+        <p id="plant-meta"></p>
+        <div id="journal-list"></div>
+
+        <h3>Добавить запись</h3>
+        <div class="form-row">
+            <label>Тип события
+                <select id="entry-type">
+                    <option value="watering">Полив</option>
+                    <option value="feeding">Удобрения</option>
+                    <option value="note">Заметка</option>
+                    <option value="photo">Фото</option>
+                    <option value="other">Другое</option>
+                </select>
+            </label>
+            <label>Дата и время
+                <input type="datetime-local" id="entry-date">
+            </label>
+        </div>
+        <label>Текст
+            <textarea id="entry-text" rows="3" placeholder="Комментарий"></textarea>
+        </label>
+        <label>Ссылки на фото (через запятую)
+            <input type="text" id="entry-photos" placeholder="https://...">
+        </label>
+        <button onclick="createEntry()">Сохранить</button>
+    </div>
+
+    <script>
+        const TOKEN_KEY = 'gh_access_token';
+        const accessToken = localStorage.getItem(TOKEN_KEY);
+        if (!accessToken) {
+            window.location.href = '/login.html';
+        }
+
+        const urlParams = new URLSearchParams(window.location.search);
+        const plantId = urlParams.get('plant_id');
+        if (!plantId) {
+            document.getElementById('journal-list').innerHTML = '<p>Не указан plant_id</p>';
+            throw new Error('no plant id');
+        }
+
+        const authFetch = async (url, options = {}) => {
+            const opts = { ...options };
+            opts.headers = { ...(options.headers || {}), Authorization: `Bearer ${accessToken}` };
+            const resp = await fetch(url, opts);
+            if (resp.status === 401 || resp.status === 403) {
+                localStorage.removeItem(TOKEN_KEY);
+                window.location.href = '/login.html';
+            }
+            return resp;
+        };
+
+        const formatDate = (value) => {
+            if (!value) return '';
+            const date = new Date(value);
+            return date.toLocaleString('ru-RU');
+        };
+
+        async function loadPlantInfo() {
+            const resp = await authFetch(`/api/plants/${plantId}`);
+            if (!resp.ok) return;
+            const plant = await resp.json();
+            document.getElementById('plant-title').innerText = `Журнал: ${plant.name}`;
+            document.getElementById('plant-meta').innerText = plant.plant_group ? `Группа: ${plant.plant_group.name}` : 'Без группы';
+        }
+
+        async function loadJournal() {
+            const resp = await authFetch(`/api/plants/${plantId}/journal`);
+            const entries = await resp.json();
+            renderJournal(entries);
+        }
+
+        function renderJournal(entries) {
+            const container = document.getElementById('journal-list');
+            if (!Array.isArray(entries) || entries.length === 0) {
+                container.innerHTML = '<p>Записей нет</p>';
+                return;
+            }
+            container.innerHTML = '';
+            entries.forEach(entry => {
+                const div = document.createElement('div');
+                div.className = 'entry';
+                const photos = (entry.photos || []).map(p => `<img src="${p.url}" alt="photo">`).join('');
+                div.innerHTML = `
+                    <div><strong>${formatDate(entry.event_at)}</strong> — ${entry.type}</div>
+                    <div>${entry.text || ''}</div>
+                    <div class="photos">${photos}</div>
+                `;
+                container.appendChild(div);
+            });
+        }
+
+        async function createEntry() {
+            const type = document.getElementById('entry-type').value;
+            const text = document.getElementById('entry-text').value;
+            const dateValue = document.getElementById('entry-date').value;
+            const photoInput = document.getElementById('entry-photos').value;
+            const payload = { type, text: text || null };
+            if (dateValue) payload.event_at = new Date(dateValue).toISOString();
+            if (photoInput.trim()) {
+                payload.photo_urls = photoInput.split(',').map(v => v.trim()).filter(Boolean);
+            }
+            const resp = await authFetch(`/api/plants/${plantId}/journal`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (resp.ok) {
+                document.getElementById('entry-text').value = '';
+                document.getElementById('entry-date').value = '';
+                document.getElementById('entry-photos').value = '';
+                await loadJournal();
+            }
+        }
+
+        async function init() {
+            await loadPlantInfo();
+            await loadJournal();
+        }
+
+        init();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add database models and migration for plant groups, plants, device links, and journals
- expose plant CRUD, grouping, device linking, and journal APIs plus admin listing
- extend frontend with plant management UI, journal page, admin plants view, and basic tests

## Testing
- pytest server/tests/test_plants_api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69258a03b2d483258db27f734c01d6d1)