### PR TITLE
Add layout engine for PlantAvatar SVG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-﻿- Dobavlen SVG-renderer s sloyami dlya PlantAvatar
+- Dobavlen layoutEngine dlya PlantAvatar, raschety geometrii pereneseny v odno mesto
+- Sloi gorshka, pochvy, steblya, list'ev i cvetov teper' ispol'zuyut obshchuyu geometriju i vyrovneny po centru kadra
+﻿- Dobavlena palitra yarkih cvetov dlya PlantAvatar (SVG)
+- Sloi gorshka, pochvy, steblya, list'ev i cvetov pererisovany v bolee vyrazitelnom SVG-stile s novoj palitroj
+
+- Dobavlen SVG-renderer s sloyami dlya PlantAvatar
 - PlantAvatar risuet uproshchennuyu SVG kompoziciyu v zavisimosti ot stadii
 - Dobavlen helper dlya opredeleniya stadii rasteniya po vozrastu
 - PlantAvatar na dashborde poluchaet stadiyu po vozrastu, a ne hardsodom

--- a/frontend/src/components/plant-avatar/engines/svg/SvgAvatarRenderer.jsx
+++ b/frontend/src/components/plant-avatar/engines/svg/SvgAvatarRenderer.jsx
@@ -4,6 +4,7 @@ import SoilLayer from './layers/SoilLayer';
 import StemLayer from './layers/StemLayer';
 import LeavesLayer from './layers/LeavesLayer';
 import FlowerLayer from './layers/FlowerLayer';
+import { computePlantLayout } from './layoutEngine';
 
 const VIEWBOX_WIDTH = 100; // Bazovaya shirina rendera 3:4
 const VIEWBOX_HEIGHT = 133; // Bazovaya vysota rendera 3:4
@@ -17,6 +18,8 @@ function SvgAvatarRenderer({ stageConfig, environment, variant, size, className 
   void variant;
   void size;
 
+  const layout = computePlantLayout(stageConfig, VIEWBOX_WIDTH, VIEWBOX_HEIGHT);
+
   return (
     <svg
       className={`plant-avatar__svg ${className || ''}`}
@@ -25,11 +28,11 @@ function SvgAvatarRenderer({ stageConfig, environment, variant, size, className 
       aria-hidden="true"
       preserveAspectRatio="xMidYMid meet"
     >
-      <PotLayer stageConfig={stageConfig} environment={environment} width={VIEWBOX_WIDTH} height={VIEWBOX_HEIGHT} />
-      <SoilLayer stageConfig={stageConfig} environment={environment} width={VIEWBOX_WIDTH} height={VIEWBOX_HEIGHT} />
-      <StemLayer stageConfig={stageConfig} environment={environment} width={VIEWBOX_WIDTH} height={VIEWBOX_HEIGHT} />
-      <LeavesLayer stageConfig={stageConfig} environment={environment} width={VIEWBOX_WIDTH} height={VIEWBOX_HEIGHT} />
-      <FlowerLayer stageConfig={stageConfig} environment={environment} width={VIEWBOX_WIDTH} height={VIEWBOX_HEIGHT} />
+      <PotLayer stageConfig={stageConfig} environment={environment} width={VIEWBOX_WIDTH} height={VIEWBOX_HEIGHT} layout={layout} />
+      <SoilLayer stageConfig={stageConfig} environment={environment} width={VIEWBOX_WIDTH} height={VIEWBOX_HEIGHT} layout={layout} />
+      <StemLayer stageConfig={stageConfig} environment={environment} width={VIEWBOX_WIDTH} height={VIEWBOX_HEIGHT} layout={layout} />
+      <LeavesLayer stageConfig={stageConfig} environment={environment} width={VIEWBOX_WIDTH} height={VIEWBOX_HEIGHT} layout={layout} />
+      <FlowerLayer stageConfig={stageConfig} environment={environment} width={VIEWBOX_WIDTH} height={VIEWBOX_HEIGHT} layout={layout} />
     </svg>
   );
 }

--- a/frontend/src/components/plant-avatar/engines/svg/layers/FlowerLayer.jsx
+++ b/frontend/src/components/plant-avatar/engines/svg/layers/FlowerLayer.jsx
@@ -1,42 +1,42 @@
-﻿import React from 'react';
+import React from 'react';
+import { PLANT_AVATAR_PALETTE } from '../palette';
 
-// Sloj cvetov: krugi v verhnej zone steblya, kolichestvo/razmer ot flowerDensity/flowerSize
-function FlowerLayer({ stageConfig, width, height }) {
+// Sloj cvetov: neytral'noe decorativnoe socvetie, zavisyashchee ot flowerDensity/flowerSize
+function FlowerLayer({ stageConfig, width, height, layout }) {
   const flowerDensity = stageConfig?.appearance?.flowerDensity ?? 0;
   const flowerSize = stageConfig?.appearance?.flowerSize ?? 0;
-  const heightFactor = stageConfig?.layout?.heightFactor ?? 0.4;
+  void width;
+  void height;
 
   if (flowerDensity <= 0 || flowerSize <= 0) {
     return null;
   }
 
-  const potHeight = height * 0.28;
-  const soilHeight = potHeight * 0.22;
-  const soilTop = height - potHeight - soilHeight;
-  const maxStemHeight = soilTop - 6;
-  const stemHeight = Math.max(8, maxStemHeight * Math.min(Math.max(heightFactor, 0), 1));
-  const stemTop = soilTop - stemHeight;
-  const centerX = width / 2;
-
-  const flowerCount = Math.max(1, Math.round(flowerDensity * 6));
-  const petals = [];
-  for (let i = 0; i < flowerCount; i += 1) {
-    const offset = (i - (flowerCount - 1) / 2) * 6;
-    const radius = Math.max(2.5, flowerSize * 5);
-    const y = stemTop + (i % 2 === 0 ? 2 : 6);
-    petals.push(
-      <g key={`flw-${i}`}>
-        <circle cx={centerX + offset} cy={y} r={radius} fill="#f2b8d8" />
-        <circle cx={centerX + offset} cy={y} r={radius * 0.45} fill="#f4e9b5" />
-      </g>,
-    );
+  const slots = layout?.flowers?.slots ?? [];
+  if (slots.length === 0) {
+    return null;
   }
 
-  return (
-    <g className="plant-avatar__layer flower-layer">
-      {petals}
-    </g>
-  );
+  const renderFlower = (slot, index) => {
+    const scale = slot.scale;
+    const petalRadius = 3.6 * scale;
+    const centerRadius = 2 * scale;
+    const petals = Array.from({ length: 6 }, (_, idx) => {
+      const angle = (idx / 6) * Math.PI * 2;
+      const px = slot.x + Math.cos(angle) * petalRadius * 1.5;
+      const py = slot.y + Math.sin(angle) * petalRadius * 1.2;
+      return <circle key={`petal-${index}-${idx}`} cx={px} cy={py} r={petalRadius} fill={PLANT_AVATAR_PALETTE.FLOWER_LIGHT} />;
+    });
+
+    return (
+      <g key={`flower-${index}`}>
+        {petals}
+        <circle cx={slot.x} cy={slot.y} r={centerRadius} fill={PLANT_AVATAR_PALETTE.FLOWER_DARK} />
+      </g>
+    );
+  };
+
+  return <g className="plant-avatar__layer flower-layer">{slots.map(renderFlower)}</g>;
 }
 
 export default FlowerLayer;

--- a/frontend/src/components/plant-avatar/engines/svg/layers/LeavesLayer.jsx
+++ b/frontend/src/components/plant-avatar/engines/svg/layers/LeavesLayer.jsx
@@ -1,49 +1,43 @@
-﻿import React from 'react';
+import React from 'react';
+import { PLANT_AVATAR_PALETTE } from '../palette';
 
-// Sloj list'ev: neskol'ko ellipsov po bokam steblya, zavisit ot leafDensity/leafSize
-function LeavesLayer({ stageConfig, width, height }) {
+const LEAF_PATH_D = 'M 0 0 C 6 -6 14 -6 16 0 C 14 6 6 10 0 0 Z';
+
+// Sloj list'ev: uproshchennaya sistema list'ev, zavisyashchaya ot leafDensity
+function LeavesLayer({ stageConfig, width, height, layout }) {
   const leafDensity = stageConfig?.appearance?.leafDensity ?? 0;
   const leafSize = stageConfig?.appearance?.leafSize ?? 0.4;
-  const heightFactor = stageConfig?.layout?.heightFactor ?? 0.4;
+  void width;
+  void height;
 
-  const potHeight = height * 0.28;
-  const soilHeight = potHeight * 0.22;
-  const soilTop = height - potHeight - soilHeight;
-  const maxStemHeight = soilTop - 6;
-  const stemHeight = Math.max(8, maxStemHeight * Math.min(Math.max(heightFactor, 0), 1));
-  const centerX = width / 2;
-
-  const leafCount = Math.max(0, Math.round(leafDensity * 8));
-  const leaves = [];
-  for (let i = 0; i < leafCount; i += 1) {
-    const progress = (i + 1) / (leafCount + 1);
-    const y = soilTop - stemHeight * progress;
-    const dir = i % 2 === 0 ? -1 : 1;
-    const offset = (8 + i) * 0.4;
-    const rx = Math.max(3, leafSize * 8);
-    const ry = Math.max(2, leafSize * 6);
-    leaves.push(
-      <ellipse
-        key={`leaf-${i}`}
-        cx={centerX + dir * offset}
-        cy={y}
-        rx={rx}
-        ry={ry}
-        fill="#74b36a"
-        transform={`rotate(${dir * 12}, ${centerX + dir * offset}, ${y})`}
-      />,
-    );
-  }
-
-  if (leafCount === 0) {
+  if (leafDensity <= 0) {
     return null;
   }
 
-  return (
-    <g className="plant-avatar__layer leaves-layer">
-      {leaves}
-    </g>
-  );
+  const slots = layout?.leaves?.slots ?? [];
+  if (slots.length === 0) {
+    return null;
+  }
+
+  const sizeScale = Math.max(0.55, Math.min(1.3, leafSize * 1.3));
+
+  const leaves = slots.map((slot, index) => {
+    const flip = slot.side === 'left' ? -1 : 1;
+    return (
+      <path
+        key={`leaf-${index}`}
+        d={LEAF_PATH_D}
+        fill={PLANT_AVATAR_PALETTE.LEAF_LIGHT}
+        stroke={PLANT_AVATAR_PALETTE.LEAF_DARK}
+        strokeWidth={1.4}
+        transform={`translate(${slot.x}, ${slot.y}) scale(${flip * sizeScale * slot.scale}, ${sizeScale * slot.scale}) rotate(${slot.side === 'left' ? -18 : 18})`}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    );
+  });
+
+  return <g className="plant-avatar__layer leaves-layer">{leaves}</g>;
 }
 
 export default LeavesLayer;

--- a/frontend/src/components/plant-avatar/engines/svg/layers/PotLayer.jsx
+++ b/frontend/src/components/plant-avatar/engines/svg/layers/PotLayer.jsx
@@ -1,29 +1,64 @@
-﻿import React from 'react';
+import React from 'react';
+import { PLANT_AVATAR_PALETTE } from '../palette';
 
-// Sloj gorshka: prostoj polygon v nizhnej chasti
-function PotLayer({ width, height }) {
-  const potHeight = height * 0.28;
-  const topY = height - potHeight;
-  const lipHeight = potHeight * 0.2;
+// Sloj gorshka: baza dlya gorshka v stile "sochnogo rasteniya"
+function PotLayer({ stageConfig, environment, width, height, layout }) {
+  void stageConfig;
+  void environment;
+  void width;
+  void height;
+
+  const bodyTopY = layout?.pot?.topY ?? height * 0.7;
+  const bodyBottomY = layout?.pot?.bottomY ?? height;
+  const rimHeight = layout?.pot?.rimHeight ?? 8;
+  const insetX = layout?.pot?.insetX ?? 8;
+  const bodyHeight = layout?.pot?.bodyHeight ?? (height * 0.3 - rimHeight);
+  const effectiveWidth = layout?.width ?? width;
+  const topWidth = effectiveWidth - insetX * 2;
+  const bottomWidth = topWidth * 0.8;
+  const topX = (effectiveWidth - topWidth) / 2;
+  const bottomX = (effectiveWidth - bottomWidth) / 2;
+
+  const bodyPath = `
+    M ${topX + 4} ${bodyTopY}
+    L ${topX + topWidth - 4} ${bodyTopY}
+    Q ${topX + topWidth} ${bodyTopY + 3} ${topX + topWidth - 5} ${bodyTopY + 12}
+    L ${bottomX + bottomWidth - 4} ${bodyBottomY - 6}
+    Q ${bottomX + bottomWidth} ${bodyBottomY - 2} ${bottomX + bottomWidth - 5} ${bodyBottomY}
+    L ${bottomX + 5} ${bodyBottomY}
+    Q ${bottomX} ${bodyBottomY - 2} ${bottomX + 5} ${bodyBottomY - 6}
+    L ${topX + 4} ${bodyTopY + 12}
+    Q ${topX} ${bodyTopY + 3} ${topX + 4} ${bodyTopY}
+    Z
+  `;
+
+  const shadowHeight = bodyHeight * 0.32;
+  const shadowPath = `
+    M ${bottomX + 6} ${bodyBottomY - shadowHeight}
+    L ${bottomX + bottomWidth - 6} ${bodyBottomY - shadowHeight + 5}
+    Q ${bottomX + bottomWidth} ${bodyBottomY - shadowHeight + 10} ${bottomX + bottomWidth - 6} ${bodyBottomY}
+    L ${bottomX + 6} ${bodyBottomY}
+    Q ${bottomX} ${bodyBottomY - 6} ${bottomX + 6} ${bodyBottomY - shadowHeight}
+    Z
+  `;
+
+  const rimWidth = topWidth * 1.04;
+  const rimX = (effectiveWidth - rimWidth) / 2;
+  const rimY = bodyTopY - rimHeight * 0.9;
+  const rimPath = `
+    M ${rimX} ${rimY}
+    L ${rimX + rimWidth} ${rimY}
+    Q ${rimX + rimWidth} ${rimY + rimHeight * 0.5} ${rimX + rimWidth - 6} ${rimY + rimHeight}
+    L ${rimX + 6} ${rimY + rimHeight}
+    Q ${rimX} ${rimY + rimHeight * 0.5} ${rimX} ${rimY}
+    Z
+  `;
 
   return (
     <g className="plant-avatar__layer pot-layer">
-      <rect
-        x={width * 0.1}
-        y={topY}
-        width={width * 0.8}
-        height={potHeight}
-        rx={6}
-        fill="#d98555"
-      />
-      <rect
-        x={width * 0.08}
-        y={topY - lipHeight * 0.6}
-        width={width * 0.84}
-        height={lipHeight}
-        rx={4}
-        fill="#c97548"
-      />
+      <path d={bodyPath} fill={PLANT_AVATAR_PALETTE.POT_BASE} />
+      <path d={shadowPath} fill={PLANT_AVATAR_PALETTE.POT_SHADOW} opacity={0.85} />
+      <path d={rimPath} fill={PLANT_AVATAR_PALETTE.POT_HIGHLIGHT} />
     </g>
   );
 }

--- a/frontend/src/components/plant-avatar/engines/svg/layers/SoilLayer.jsx
+++ b/frontend/src/components/plant-avatar/engines/svg/layers/SoilLayer.jsx
@@ -1,29 +1,72 @@
-﻿import React from 'react';
+import React from 'react';
+import { PLANT_AVATAR_PALETTE } from '../palette';
 
-// Sloj pochvy: prostaya poloska nad gorshkom s tsvetom ot vlagi
-function SoilLayer({ environment, width, height }) {
-  const potHeight = height * 0.28;
-  const soilHeight = potHeight * 0.22;
-  const topY = height - potHeight - soilHeight;
+// Sloj pochvy: myagkaya volna s tsvetom ot vlagi
+const hexToRgb = (hex) => {
+  const normalized = hex.replace('#', '');
+  const value = parseInt(normalized, 16);
+  return {
+    r: (value >> 16) & 255,
+    g: (value >> 8) & 255,
+    b: value & 255,
+  };
+};
 
-  const moisture = environment?.soilMoisture ?? null;
-  const moisturePct = Number.isFinite(Number(moisture)) ? Math.min(Math.max(Number(moisture), 0), 100) : null;
-  // Bol'she vlazhnost' — temnee pochva
-  const drynessFactor = moisturePct === null ? 0.4 : 1 - moisturePct / 100;
-  const baseColor = 180;
-  const colorShift = Math.round(40 * drynessFactor);
-  const soilColor = `rgb(${baseColor - colorShift}, ${120 - colorShift}, ${70 - colorShift})`;
+const mixColors = (from, to, ratio) => ({
+  r: Math.round(from.r * (1 - ratio) + to.r * ratio),
+  g: Math.round(from.g * (1 - ratio) + to.g * ratio),
+  b: Math.round(from.b * (1 - ratio) + to.b * ratio),
+});
+
+// Funkciya vybora cveta pochvy po soilMoisture
+const pickSoilColor = (moisture) => {
+  const wet = hexToRgb(PLANT_AVATAR_PALETTE.SOIL_WET);
+  const dry = hexToRgb(PLANT_AVATAR_PALETTE.SOIL_DRY);
+  const hasValue = Number.isFinite(Number(moisture));
+  if (!hasValue) {
+    const mid = mixColors(wet, dry, 0.5);
+    return `rgb(${mid.r}, ${mid.g}, ${mid.b})`;
+  }
+
+  const pct = Math.min(Math.max(Number(moisture), 0), 100);
+  let drynessRatio = 0.5;
+  if (pct < 30) {
+    drynessRatio = 0.85;
+  } else if (pct > 70) {
+    drynessRatio = 0.15;
+  } else {
+    const span = 70 - 30;
+    const progress = (pct - 30) / span;
+    drynessRatio = 0.85 - progress * (0.85 - 0.15);
+  }
+
+  const mixed = mixColors(wet, dry, drynessRatio);
+  return `rgb(${mixed.r}, ${mixed.g}, ${mixed.b})`;
+};
+
+function SoilLayer({ environment, width, height, layout }) {
+  void width;
+  void height;
+  const soilTop = layout?.soil?.topY ?? height * 0.6;
+  const soilBase = layout?.soil?.bottomY ?? height * 0.7;
+  const soilWidth = (layout?.width ?? width) * 0.76;
+  const soilX = ((layout?.width ?? width) - soilWidth) / 2;
+  const curveRise = (soilBase - soilTop) * 0.5;
+
+  const soilPath = `
+    M ${soilX} ${soilBase}
+    L ${soilX} ${soilTop + (soilBase - soilTop) * 0.35}
+    Q ${soilX + soilWidth * 0.25} ${soilTop - curveRise} ${soilX + soilWidth / 2} ${soilTop}
+    Q ${soilX + soilWidth * 0.75} ${soilTop - curveRise} ${soilX + soilWidth} ${soilTop + (soilBase - soilTop) * 0.35}
+    L ${soilX + soilWidth} ${soilBase}
+    Z
+  `;
+
+  const soilColor = pickSoilColor(environment?.soilMoisture);
 
   return (
     <g className="plant-avatar__layer soil-layer">
-      <rect
-        x={width * 0.1}
-        y={topY}
-        width={width * 0.8}
-        height={soilHeight}
-        rx={3}
-        fill={soilColor}
-      />
+      <path d={soilPath} fill={soilColor} />
     </g>
   );
 }

--- a/frontend/src/components/plant-avatar/engines/svg/layers/StemLayer.jsx
+++ b/frontend/src/components/plant-avatar/engines/svg/layers/StemLayer.jsx
@@ -1,28 +1,48 @@
-﻿import React from 'react';
+import React from 'react';
+import { PLANT_AVATAR_PALETTE } from '../palette';
 
-// Sloj steblya: odna kolonka, vysota ot heightFactor, tolshchina ot stemThickness
-function StemLayer({ stageConfig, width, height }) {
-  const heightFactor = stageConfig?.layout?.heightFactor ?? 0.4;
-  const stemThickness = stageConfig?.appearance?.stemThickness ?? 0.25;
+// Sloj steblya: zhivaya stoyka s legkim szhatiem kverhu
+function StemLayer({ stageConfig, width, height, layout }) {
+  void stageConfig;
+  void width;
+  void height;
 
-  const potHeight = height * 0.28;
-  const soilHeight = potHeight * 0.22;
-  const soilTop = height - potHeight - soilHeight;
-  const maxStemHeight = soilTop - 6;
-  const stemHeight = Math.max(8, maxStemHeight * Math.min(Math.max(heightFactor, 0), 1));
-  const centerX = width / 2;
-  const stemWidth = Math.max(2, stemThickness * 8);
+  const stemHeight = layout?.stem?.height ?? 40;
+  const centerX = layout?.stem?.baseX ?? (width / 2);
+  const soilTop = layout?.stem?.baseY ?? height * 0.65;
+  const bottomWidth = Math.max(3, layout?.stem?.thickness ?? 6);
+  const topWidth = bottomWidth * 0.72;
+  const stemTopY = soilTop - stemHeight;
+
+  const leftBottom = centerX - bottomWidth / 2;
+  const rightBottom = centerX + bottomWidth / 2;
+  const leftTop = centerX - topWidth / 2;
+  const rightTop = centerX + topWidth / 2;
+
+  const stemPath = `
+    M ${leftBottom} ${soilTop}
+    L ${rightBottom} ${soilTop}
+    Q ${rightBottom + 2} ${soilTop - 6} ${rightTop} ${stemTopY + 6}
+    Q ${rightTop} ${stemTopY} ${rightTop - 2} ${stemTopY}
+    L ${leftTop + 2} ${stemTopY}
+    Q ${leftTop} ${stemTopY} ${leftTop} ${stemTopY + 6}
+    Q ${leftBottom - 2} ${soilTop - 6} ${leftBottom} ${soilTop}
+    Z
+  `;
+
+  const shadowWidth = Math.max(2, bottomWidth * 0.35);
+  const shadowPath = `
+    M ${rightTop - 1} ${stemTopY + 4}
+    L ${rightBottom} ${soilTop}
+    L ${rightBottom - shadowWidth} ${soilTop}
+    L ${rightTop - shadowWidth * 0.6} ${stemTopY + 6}
+    Z
+  `;
 
   return (
     <g className="plant-avatar__layer stem-layer">
-      <rect
-        x={centerX - stemWidth / 2}
-        y={soilTop - stemHeight}
-        width={stemWidth}
-        height={stemHeight}
-        rx={stemWidth / 2}
-        fill="#4f8b4a"
-      />
+      <path d={stemPath} fill={PLANT_AVATAR_PALETTE.STEM_BASE} />
+      <path d={shadowPath} fill={PLANT_AVATAR_PALETTE.STEM_SHADOW} opacity={0.95} />
     </g>
   );
 }

--- a/frontend/src/components/plant-avatar/engines/svg/layoutEngine.js
+++ b/frontend/src/components/plant-avatar/engines/svg/layoutEngine.js
@@ -1,0 +1,119 @@
+// Funksiya dlya rascheta edinogo layouta PlantAvatar
+// Vse koordinaty rasschityvayutsya vnutri edinogo viewBox, chtoby sloi byli vyrovneny
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+// Kommentarii na russkom translitom: eto layout-dvizhok, kotorый sobiraet geometriju
+function computePlantLayout(stageConfig, width, height) {
+  const heightFactor = clamp(stageConfig?.layout?.heightFactor ?? 0.5, 0, 1);
+  const stemThicknessFactor = clamp(stageConfig?.appearance?.stemThickness ?? 0.25, 0, 1);
+  const leafDensity = clamp(stageConfig?.appearance?.leafDensity ?? 0, 0, 1);
+  const flowerDensity = clamp(stageConfig?.appearance?.flowerDensity ?? 0, 0, 1);
+  const flowerSize = clamp(stageConfig?.appearance?.flowerSize ?? 0, 0, 1);
+
+  const potHeight = height * 0.3;
+  const rimHeight = potHeight * 0.18;
+  const bodyHeight = potHeight - rimHeight;
+  const insetX = width * 0.1;
+
+  const potBottomY = height;
+  const potTopY = potBottomY - bodyHeight;
+
+  const soilHeight = potHeight * 0.18;
+  const soilBottomY = potTopY - rimHeight * 0.1;
+  const soilTopY = soilBottomY - soilHeight;
+
+  const plantTopMargin = height * 0.1;
+  const plantBottomY = soilTopY;
+  const plantTopY = plantTopMargin;
+  const plantHeight = Math.max(plantBottomY - plantTopY, 10);
+
+  const stemHeight = Math.max(8, plantHeight * heightFactor);
+  const stemThickness = 4 + stemThicknessFactor * 6;
+  const stemBaseX = width / 2;
+  const stemBaseY = plantBottomY;
+
+  const leafSlots = [];
+  const minLeaves = 2;
+  const midLeaves = 5;
+  const maxLeaves = 7;
+  let leafCount = minLeaves;
+  if (leafDensity >= 0.7) {
+    leafCount = maxLeaves;
+  } else if (leafDensity >= 0.3) {
+    leafCount = midLeaves;
+  }
+
+  const leafSpan = stemHeight * 0.8;
+  const leafStartY = stemBaseY - leafSpan * 0.2;
+  const leafStep = leafSpan / Math.max(leafCount, 1);
+  for (let i = 0; i < leafCount; i += 1) {
+    const side = i % 2 === 0 ? 'left' : 'right';
+    const y = leafStartY - i * leafStep;
+    const xOffset = stemThickness * 1.8 + (i % 3) * 2;
+    const scale = 0.9 + (i % 2) * 0.1;
+    leafSlots.push({
+      x: stemBaseX + (side === 'left' ? -xOffset : xOffset),
+      y,
+      scale,
+      side,
+    });
+  }
+
+  const flowers = [];
+  if (flowerDensity > 0 && flowerSize > 0) {
+    let flowerCount = 1;
+    if (flowerDensity >= 0.7) {
+      flowerCount = 4;
+    } else if (flowerDensity >= 0.3) {
+      flowerCount = 3;
+    }
+
+    const stemTopY = stemBaseY - stemHeight;
+    const spread = stemThickness * 1.2;
+    for (let i = 0; i < flowerCount; i += 1) {
+      const offset = i - (flowerCount - 1) / 2;
+      const x = stemBaseX + offset * spread;
+      const y = stemTopY - 4 - Math.abs(offset) * 2;
+      const scale = 0.7 + flowerSize * 0.8;
+      flowers.push({ x, y, scale });
+    }
+  }
+
+  return {
+    width,
+    height,
+    pot: {
+      bottomY: potBottomY,
+      topY: potTopY,
+      rimHeight,
+      bodyHeight,
+      insetX,
+    },
+    soil: {
+      topY: soilTopY,
+      bottomY: soilBottomY,
+    },
+    plantArea: {
+      topY: plantTopY,
+      bottomY: plantBottomY,
+      height: plantHeight,
+    },
+    stem: {
+      baseX: stemBaseX,
+      baseY: stemBaseY,
+      height: stemHeight,
+      thickness: stemThickness,
+    },
+    leaves: {
+      slots: leafSlots,
+    },
+    flowers: {
+      slots: flowers,
+    },
+  };
+}
+
+export { computePlantLayout };

--- a/frontend/src/components/plant-avatar/engines/svg/palette.js
+++ b/frontend/src/components/plant-avatar/engines/svg/palette.js
@@ -1,0 +1,16 @@
+﻿const PLANT_AVATAR_PALETTE = {
+  POT_BASE: '#d46a3c',
+  POT_SHADOW: '#b7542f',
+  POT_HIGHLIGHT: '#e78b5c',
+  SOIL_WET: '#5b3a24',
+  SOIL_DRY: '#8a6335',
+  STEM_BASE: '#44a65a',
+  STEM_SHADOW: '#2f7f43',
+  LEAF_LIGHT: '#61c15d',
+  LEAF_DARK: '#3b9b4a',
+  FLOWER_LIGHT: '#ffb54d',
+  FLOWER_DARK: '#e17d2d',
+};
+
+// Eto obshchaya palitra dlya PlantAvatar
+export { PLANT_AVATAR_PALETTE };


### PR DESCRIPTION
## Summary
- add a centralized layout engine for PlantAvatar to compute shared geometry
- update pot, soil, stem, leaves, and flowers to use the unified layout for centering and alignment
- refresh the changelog with the new layout engine entry

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69389ea2bacc832587d2708a596c2f5b)