### PR TITLE
Finalize manual watering on device state update and propagate pumpId in shadow state

### DIFF
--- a/backend/src/main/java/ru/growerhub/backend/device/DeviceFacade.java
+++ b/backend/src/main/java/ru/growerhub/backend/device/DeviceFacade.java
@@ -122,6 +122,7 @@ public class DeviceFacade {
         if (devicePk != null) {
             pumpFacade.ensureDefaultPump(devicePk);
         }
+        pumpFacade.finalizeWateringByDeviceId(deviceId, now);
         List<SensorReadingSummary> summaries = sensorFacade.recordMeasurements(deviceId, measurements, now);
         plantFacade.recordFromSensorBindings(summaries);
     }
@@ -379,6 +380,5 @@ public class DeviceFacade {
     }
 
 }
-
 
 

--- a/backend/src/main/java/ru/growerhub/backend/device/contract/DeviceShadowState.java
+++ b/backend/src/main/java/ru/growerhub/backend/device/contract/DeviceShadowState.java
@@ -26,6 +26,7 @@ public record DeviceShadowState(
             LocalDateTime startedAt,
             @JsonProperty("remaining_s") Integer remainingS,
             @JsonProperty("correlation_id") String correlationId,
+            @JsonProperty("pump_id") Integer pumpId,
             @JsonProperty("water_volume_l") Double waterVolumeL,
             @JsonProperty("ph") Double ph,
             @JsonProperty("fertilizers_per_liter") String fertilizersPerLiter,

--- a/backend/src/main/java/ru/growerhub/backend/device/engine/DeviceShadowStore.java
+++ b/backend/src/main/java/ru/growerhub/backend/device/engine/DeviceShadowStore.java
@@ -270,6 +270,7 @@ public class DeviceShadowStore {
                 preferNonNull(current.startedAt(), prev.startedAt()),
                 preferNonNull(current.remainingS(), prev.remainingS()),
                 correlationId,
+                preferNonNull(current.pumpId(), prev.pumpId()),
                 preferNonNull(current.waterVolumeL(), prev.waterVolumeL()),
                 preferNonNull(current.ph(), prev.ph()),
                 preferNonBlank(current.fertilizersPerLiter(), prev.fertilizersPerLiter()),

--- a/backend/src/main/java/ru/growerhub/backend/mqtt/MqttMessageHandler.java
+++ b/backend/src/main/java/ru/growerhub/backend/mqtt/MqttMessageHandler.java
@@ -191,6 +191,7 @@ public class MqttMessageHandler {
                     null,
                     null,
                     null,
+                    null,
                     null
             );
         }

--- a/backend/src/main/java/ru/growerhub/backend/pump/PumpFacade.java
+++ b/backend/src/main/java/ru/growerhub/backend/pump/PumpFacade.java
@@ -1,5 +1,6 @@
 ﻿package ru.growerhub.backend.pump;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -82,6 +83,11 @@ public class PumpFacade {
         return wateringService.getAck(correlationId);
     }
 
+    @Transactional
+    public void finalizeWateringByDeviceId(String deviceId, LocalDateTime now) {
+        wateringService.finalizeWateringByDeviceId(deviceId, now);
+    }
+
     @Transactional(readOnly = true)
     public List<PumpView> listByDeviceId(Integer deviceId, DeviceShadowState state) {
         return queryService.listByDevice(deviceId, state);
@@ -113,5 +119,3 @@ public class PumpFacade {
     public record PumpWateringRequest(Integer durationS, Double waterVolumeL, Double ph, String fertilizersPerLiter) {
     }
 }
-
-

--- a/backend/src/main/java/ru/growerhub/backend/pump/engine/PumpWateringService.java
+++ b/backend/src/main/java/ru/growerhub/backend/pump/engine/PumpWateringService.java
@@ -93,6 +93,7 @@ public class PumpWateringService {
                 startedAt,
                 durationS,
                 correlationId,
+                pump.getId(),
                 plannedWaterVolumeL,
                 request.ph(),
                 request.fertilizersPerLiter(),
@@ -142,6 +143,54 @@ public class PumpWateringService {
 
     public PumpAck getAck(String correlationId) {
         return commandGateway.getAck(correlationId);
+    }
+
+    public void finalizeWateringByDeviceId(String deviceId, LocalDateTime now) {
+        if (deviceId == null || deviceId.isBlank()) {
+            return;
+        }
+        DeviceShadowState shadow = deviceFacade.getShadowState(deviceId);
+        DeviceShadowState.ManualWateringState manual = shadow != null ? shadow.manualWatering() : null;
+        if (manual == null) {
+            return;
+        }
+        PumpEntity pump = resolvePumpForFinalization(deviceId, manual);
+        if (pump == null) {
+            return;
+        }
+        AuthenticatedUser ownerUser = resolveOwnerUser(pump);
+        if (ownerUser == null) {
+            return;
+        }
+        finalizeWateringIfNeeded(pump, deviceId, ownerUser, false, now);
+    }
+
+    private PumpEntity resolvePumpForFinalization(String deviceId, DeviceShadowState.ManualWateringState manual) {
+        if (manual == null) {
+            return null;
+        }
+        Integer manualPumpId = manual.pumpId();
+        if (manualPumpId != null) {
+            PumpEntity byManualId = pumpRepository.findById(manualPumpId).orElse(null);
+            if (byManualId == null) {
+                return null;
+            }
+            String pumpDeviceId = resolveDeviceId(byManualId);
+            if (pumpDeviceId == null || !pumpDeviceId.equals(deviceId)) {
+                return null;
+            }
+            return byManualId;
+        }
+
+        Integer devicePk = deviceFacade.findDeviceId(deviceId);
+        if (devicePk == null) {
+            return null;
+        }
+        List<PumpEntity> pumps = pumpRepository.findAllByDeviceId(devicePk);
+        if (pumps == null || pumps.size() != 1) {
+            return null;
+        }
+        return pumps.get(0);
     }
 
     private int calculateDurationFromVolume(List<PumpPlantBindingEntity> bindings, double volumeL) {
@@ -314,6 +363,7 @@ public class PumpWateringService {
                 startedAt,
                 0,
                 correlationId,
+                pump.getId(),
                 manual.waterVolumeL(),
                 manual.ph(),
                 manual.fertilizersPerLiter(),
@@ -388,9 +438,14 @@ public class PumpWateringService {
         }
         return deviceFacade.getDeviceSummary(pump.getDeviceId());
     }
+
+    private AuthenticatedUser resolveOwnerUser(PumpEntity pump) {
+        DeviceSummary summary = resolveDeviceSummary(pump);
+        if (summary == null || summary.userId() == null) {
+            return null;
+        }
+        return new AuthenticatedUser(summary.userId(), "user");
+    }
 }
-
-
-
 
 

--- a/backend/src/test/java/ru/growerhub/backend/api/ManualWateringIntegrationTest.java
+++ b/backend/src/test/java/ru/growerhub/backend/api/ManualWateringIntegrationTest.java
@@ -15,6 +15,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Assertions;
@@ -29,6 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import ru.growerhub.backend.IntegrationTestBase;
+import ru.growerhub.backend.device.DeviceFacade;
 import ru.growerhub.backend.device.contract.DeviceShadowState;
 import ru.growerhub.backend.device.engine.DeviceShadowStore;
 import ru.growerhub.backend.device.jpa.DeviceEntity;
@@ -50,6 +53,7 @@ import ru.growerhub.backend.plant.jpa.PlantRepository;
 import ru.growerhub.backend.pump.jpa.PumpEntity;
 import ru.growerhub.backend.pump.jpa.PumpPlantBindingEntity;
 import ru.growerhub.backend.pump.jpa.PumpPlantBindingRepository;
+import ru.growerhub.backend.pump.jpa.PumpRepository;
 import ru.growerhub.backend.pump.engine.PumpService;
 import ru.growerhub.backend.user.jpa.UserEntity;
 import ru.growerhub.backend.user.jpa.UserRepository;
@@ -72,7 +76,13 @@ class ManualWateringIntegrationTest extends IntegrationTestBase {
     private DeviceRepository deviceRepository;
 
     @Autowired
+    private DeviceFacade deviceFacade;
+
+    @Autowired
     private PumpPlantBindingRepository pumpPlantBindingRepository;
+
+    @Autowired
+    private PumpRepository pumpRepository;
 
     @Autowired
     private PumpService pumpService;
@@ -196,6 +206,130 @@ class ManualWateringIntegrationTest extends IntegrationTestBase {
 
         Assertions.assertEquals(0, plantJournalEntryRepository.count());
         Assertions.assertEquals(0, plantJournalWateringDetailsRepository.count());
+    }
+
+    @Test
+    void stateUpdateFinalizesWateringAndWritesJournal() {
+        UserEntity user = createUser("owner-finalize@example.com", "user");
+        DeviceEntity device = createDevice("mw-finalize", user);
+        PumpEntity pump = pumpService.ensureDefaultPump(device.getId());
+        PlantEntity plant = createPlant(user, "Dill");
+        bindPump(pump, plant, 1800);
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("duration_s", 5);
+
+        String token = buildToken(user.getId());
+
+        String correlationId = given()
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body(payload)
+                .when()
+                .post("/api/pumps/" + pump.getId() + "/watering/start")
+                .then()
+                .statusCode(200)
+                .body("correlation_id", notNullValue())
+                .extract()
+                .path("correlation_id");
+
+        LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+        DeviceShadowState state = new DeviceShadowState(
+                new DeviceShadowState.ManualWateringState(
+                        "idle",
+                        null,
+                        null,
+                        0,
+                        correlationId,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                ),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        deviceFacade.handleState(device.getDeviceId(), state, now);
+
+        Assertions.assertEquals(1, plantJournalEntryRepository.count());
+        Assertions.assertEquals(1, plantJournalWateringDetailsRepository.count());
+    }
+
+    @Test
+    void stateUpdateFinalizesOnlyRunningPumpAndWritesForAllItsPlants() {
+        UserEntity user = createUser("owner-finalize-multi@example.com", "user");
+        DeviceEntity device = createDevice("mw-finalize-multi", user);
+        PumpEntity defaultPump = pumpService.ensureDefaultPump(device.getId());
+        PumpEntity secondPump = PumpEntity.create();
+        secondPump.setDeviceId(device.getId());
+        secondPump.setChannel(1);
+        secondPump = pumpRepository.save(secondPump);
+
+        PlantEntity plantA = createPlant(user, "Pump-A plant");
+        PlantEntity plantB = createPlant(user, "Pump-B plant #1");
+        PlantEntity plantC = createPlant(user, "Pump-B plant #2");
+        bindPump(defaultPump, plantA, 1200);
+        bindPump(secondPump, plantB, 1800);
+        bindPump(secondPump, plantC, 1500);
+
+        String token = buildToken(user.getId());
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("duration_s", 5);
+
+        String correlationId = given()
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body(payload)
+                .when()
+                .post("/api/pumps/" + secondPump.getId() + "/watering/start")
+                .then()
+                .statusCode(200)
+                .body("correlation_id", notNullValue())
+                .extract()
+                .path("correlation_id");
+
+        LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+        DeviceShadowState state = new DeviceShadowState(
+                new DeviceShadowState.ManualWateringState(
+                        "idle",
+                        null,
+                        null,
+                        0,
+                        correlationId,
+                        secondPump.getId(),
+                        null,
+                        null,
+                        null,
+                        null
+                ),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        deviceFacade.handleState(device.getDeviceId(), state, now);
+
+        Assertions.assertEquals(2, plantJournalEntryRepository.count());
+        Set<Integer> plantIds = plantJournalEntryRepository.findAll().stream()
+                .map(entry -> entry.getPlantId())
+                .collect(Collectors.toSet());
+        Assertions.assertEquals(Set.of(plantB.getId(), plantC.getId()), plantIds);
+        Assertions.assertFalse(plantIds.contains(plantA.getId()));
     }
 
     @Test
@@ -439,6 +573,7 @@ class ManualWateringIntegrationTest extends IntegrationTestBase {
                 null,
                 null,
                 null,
+                null,
                 null
         );
         shadowStore.updateFromState(
@@ -646,11 +781,6 @@ class ManualWateringIntegrationTest extends IntegrationTestBase {
     private record PublishedCommand(String deviceId, Object cmd) {
     }
 }
-
-
-
-
-
 
 
 

--- a/backend/src/test/java/ru/growerhub/backend/api/PlantsIntegrationTest.java
+++ b/backend/src/test/java/ru/growerhub/backend/api/PlantsIntegrationTest.java
@@ -425,6 +425,7 @@ class PlantsIntegrationTest extends IntegrationTestBase {
                 null,
                 null,
                 null,
+                null,
                 null
         );
         DeviceShadowState state = new DeviceShadowState(manual, null, null, null, null, null, null, null, null, null);
@@ -869,7 +870,6 @@ class PlantsIntegrationTest extends IntegrationTestBase {
         jdbcTemplate.update("DELETE FROM users");
     }
 }
-
 
 
 

--- a/backend/src/test/java/ru/growerhub/backend/mqtt/DeviceShadowStoreTest.java
+++ b/backend/src/test/java/ru/growerhub/backend/mqtt/DeviceShadowStoreTest.java
@@ -42,6 +42,7 @@ class DeviceShadowStoreTest {
                 null,
                 null,
                 null,
+                null,
                 null
         );
         store.updateFromState("device-1", new DeviceShadowState(manual, null, null, null, null, null, null, null, null, null));


### PR DESCRIPTION
### Motivation
- Ensure manual watering gets finalized when a device publishes a state update so journal entries are created and pump runs are closed out.
- Carry the selected pump identity through the device shadow so finalization can target the correct pump when multiple pumps exist on a device.

### Description
- Add `pump_id` to `DeviceShadowState.ManualWateringState` and propagate it in `DeviceShadowStore` and `MqttMessageHandler` mappings.
- Call `pumpFacade.finalizeWateringByDeviceId(deviceId, now)` from `DeviceFacade.handleState` to trigger finalization on state updates.
- Add `PumpFacade.finalizeWateringByDeviceId` and implement `PumpWateringService.finalizeWateringByDeviceId` with helper methods `resolvePumpForFinalization` and `resolveOwnerUser` to locate the appropriate `PumpEntity` and owner before running existing finalization logic.
- Include the pump id on manual watering state writes when starting and completing watering so the finalization can identify the active pump.
- Update tests and imports accordingly to exercise the new behavior.

### Testing
- Added integration tests `stateUpdateFinalizesWateringAndWritesJournal` and `stateUpdateFinalizesOnlyRunningPumpAndWritesForAllItsPlants` in `ManualWateringIntegrationTest` and updated `DeviceShadowStoreTest` to include the new field; these exercise multi-pump and single-pump finalization paths.
- Ran unit and integration tests with `mvn -DskipTests=false test`, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebde3e79e88325b7b8c310016dc3cb)